### PR TITLE
Add drupal/real_aes and drupal/tfa that cloud_orchestrator profile requires

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,8 +106,10 @@
     "drupal/openid_connect_daccount": "1.x-dev@dev",
     "drupal/password_policy": "^4",
     "drupal/queue_ui": "^3",
+    "drupal/real_aes": "^2",
     "drupal/roleassign": "^2",
     "drupal/simple_oauth": "^5",
+    "drupal/tfa": "^2",
     "drush/drush": "^11"
   },
   "require-dev": {


### PR DESCRIPTION
@naoi I need to add `real_aes` and `tfa` since the profile requires them.